### PR TITLE
match Unexpected Overwrite error text to reworded email

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -25,9 +25,10 @@ These are the common errors, what they mean, and how they can be resolved.
 
 Error text:
 > Error importing the following sample unique ids because these sample results
-> have already been imported, yet \<OverwriteResult\> is NOT set to "true".
-> (Ensure you haven't repeated an 'FMISSampleID more than once) Sample unique
-> ids were: {sample_ids}
+> have already been imported. To re-import and overwrite them, the overwrite
+> element must be sent exactly as \<OverwriteResult\>true\</OverwriteResult\> as
+> a sibling to the FMISSampleID node. Also ensure you haven't repeated an
+> FMISSampleID more than once. Sample unique ids were: {sample_ids}
 
 This error occurs when there a FMISSampleID in the results XML matches a sample
 in the Agworld system but that sample already has results attached to it. This


### PR DESCRIPTION
## What

Updates the quoted **Error text** under `## Unexpected Overwrite` in `ERRORS.md` to match the reworded lab import failure email (website repo, same ticket).

The old block quoted the previous message verbatim — including the misleading `"true"` and stray apostrophe — so a lab that received the new email and searched this doc by the text would no longer match. This keeps the doc in sync.

## Notes

- The `\<...\>` Markdown-escaping and `{sample_ids}` placeholder conventions are preserved.
- The self-referential "For more help, see …" URL from the email is **not** reproduced in the quote block (it points back to this doc).
- The resolution steps below the quote already describe adding `<OverwriteResult>` as a sibling of `<FMISSampleID>`, so they're unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)